### PR TITLE
nixfmt: 0.5.0-rfc-2023-12-13 -> 0.5.0-rfc-2024-01-03

### DIFF
--- a/pkgs/nixfmt/default.nix
+++ b/pkgs/nixfmt/default.nix
@@ -3,12 +3,12 @@
   nixfmt,
 }:
 nixfmt.overrideAttrs (finalAttrs: prevAttrs: {
-  version = prevAttrs.version + "-rfc-2023-12-13";
+  version = prevAttrs.version + "-rfc-2024-01-04";
   name = "${prevAttrs.pname}-${finalAttrs.version}";
   src = fetchFromGitHub {
     owner = "piegamesde";
     repo = "nixfmt";
-    rev = "0a8c246723bdd16207bb03681614892fa1d2f9b5";
-    hash = "sha256-vRhF9hE4P8rwcEtPYcEuoIHvCUiI+37OeHW/QRtnMQk=";
+    rev = "35da23233a1cfd799d2b59cee056ece6dff06ea1";
+    hash = "sha256-g6n0K5VsD0MitRXJ0mrspGP7R9VKJYNwJFZRmBop1Nw=";
   };
 })


### PR DESCRIPTION
Diff: https://github.com/piegamesde/nixfmt/compare/0a8c246723bdd16207bb03681614892fa1d2f9b5...35da23233a1cfd799d2b59cee056ece6dff06ea1