### PR TITLE
nixfmt: 0.5.0-rfc-2024-01-04 -> 0.5.0-rfc-2024-01-08

### DIFF
--- a/pkgs/nixfmt/default.nix
+++ b/pkgs/nixfmt/default.nix
@@ -3,12 +3,12 @@
   nixfmt,
 }:
 nixfmt.overrideAttrs (finalAttrs: prevAttrs: {
-  version = prevAttrs.version + "-rfc-2024-01-04";
+  version = prevAttrs.version + "-rfc-2024-01-08";
   name = "${prevAttrs.pname}-${finalAttrs.version}";
   src = fetchFromGitHub {
     owner = "piegamesde";
     repo = "nixfmt";
-    rev = "35da23233a1cfd799d2b59cee056ece6dff06ea1";
-    hash = "sha256-g6n0K5VsD0MitRXJ0mrspGP7R9VKJYNwJFZRmBop1Nw=";
+    rev = "a273e5ae71bf74c4a53d1818fc2e2e6cc703bab4";
+    hash = "sha256-z9FgYQuP0IG0bPJdtwrBbpf58z33nsqi1SMe98EHEBI=";
   };
 })


### PR DESCRIPTION
Diff: https://github.com/piegamesde/nixfmt/compare/35da23233a1cfd799d2b59cee056ece6dff06ea1...a273e5ae71bf74c4a53d1818fc2e2e6cc703bab4