### PR TITLE
zen-browser: set sourceRoot to fix "unpacker produced multiple direct…

### DIFF
--- a/pkgs/zen-browser/default.nix
+++ b/pkgs/zen-browser/default.nix
@@ -8,6 +8,8 @@
 stdenvNoCC.mkDerivation {
   inherit (source) pname version src;
 
+  sourceRoot = "Zen Browser.app";
+
   nativeBuildInputs = [ undmg ];
 
   preferLocalBuild = true;


### PR DESCRIPTION
…ories"