### PR TITLE
Vendor buildFirefoxXpiAddon to fix flake check errors

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -35,26 +35,6 @@
         },
         "version": "e5d826e81b5997cbfe73c183617a9cba1af2431d"
     },
-    "firefox-addons": {
-        "cargoLocks": null,
-        "date": "2025-08-15",
-        "extract": null,
-        "name": "firefox-addons",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "rev": "e6c2e889b34f5f623a7749a46e2aa5ea6e7256a0",
-            "sha256": "sha256-KVPjWo/RVQBQe6N03cNbSVM/xNCv2506wE4A8wL73sk=",
-            "sparseCheckout": [],
-            "type": "git",
-            "url": "https://gitlab.com/rycee/nur-expressions"
-        },
-        "version": "e6c2e889b34f5f623a7749a46e2aa5ea6e7256a0"
-    },
     "hammerspoon": {
         "cargoLocks": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -21,20 +21,6 @@
     };
     date = "2025-08-15";
   };
-  firefox-addons = {
-    pname = "firefox-addons";
-    version = "e6c2e889b34f5f623a7749a46e2aa5ea6e7256a0";
-    src = fetchgit {
-      url = "https://gitlab.com/rycee/nur-expressions";
-      rev = "e6c2e889b34f5f623a7749a46e2aa5ea6e7256a0";
-      fetchSubmodules = false;
-      deepClone = false;
-      leaveDotGit = false;
-      sparseCheckout = [ ];
-      sha256 = "sha256-KVPjWo/RVQBQe6N03cNbSVM/xNCv2506wE4A8wL73sk=";
-    };
-    date = "2025-08-15";
-  };
   hammerspoon = {
     pname = "hammerspoon";
     version = "1.0.0";

--- a/default.nix
+++ b/default.nix
@@ -37,9 +37,42 @@ rec {
 
   my-firefox-addons = pkgs.recurseIntoAttrs (
     pkgs.callPackage ./pkgs/firefox-addons {
-      inherit (pkgs.callPackage "${sources.firefox-addons.src}/pkgs/firefox-addons" { })
-        buildFirefoxXpiAddon
-        ;
+      # buildFirefoxXpiAddon function vendored from https://gitlab.com/rycee/nur-expressions
+      # Original source: https://gitlab.com/rycee/nur-expressions/-/blob/master/pkgs/firefox-addons/default.nix
+      # Licensed under MIT License
+      # Copyright (c) Robert Helgesson
+      # Vendored to avoid "path is not valid" errors when running `nix flake check --no-build` in downstream flakes
+      buildFirefoxXpiAddon = pkgs.lib.makeOverridable (
+        {
+          pname,
+          version,
+          addonId,
+          url,
+          sha256,
+          meta,
+          ...
+        }:
+        pkgs.stdenv.mkDerivation {
+          name = "${pname}-${version}";
+
+          inherit meta;
+
+          src = pkgs.fetchurl { inherit url sha256; };
+
+          preferLocalBuild = true;
+          allowSubstitutes = true;
+
+          passthru = {
+            inherit addonId;
+          };
+
+          buildCommand = ''
+            dst="$out/share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
+            mkdir -p "$dst"
+            install -v -m644 "$src" "$dst/${addonId}.xpi"
+          '';
+        }
+      );
     }
   );
 

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -8,11 +8,6 @@ src.git = "https://github.com/d12frosted/homebrew-emacs-plus"
 src.branch = "master"
 fetch.github = "d12frosted/homebrew-emacs-plus"
 
-[firefox-addons]
-src.git = "https://gitlab.com/rycee/nur-expressions"
-src.branch = "master"
-fetch.git = "https://gitlab.com/rycee/nur-expressions"
-
 [hammerspoon]
 src.github = "Hammerspoon/hammerspoon"
 fetch.url = "https://github.com/Hammerspoon/hammerspoon/releases/download/$ver/Hammerspoon-$ver.zip"


### PR DESCRIPTION
## Summary
- Vendored the `buildFirefoxXpiAddon` function from rycee/nur-expressions repository
- Added proper MIT license attribution and copyright notice
- Removed external dependency on firefox-addons source

## Test plan
- [x] Ensure `nix flake check --no-build` runs without "path is not valid" errors in downstream flakes
- [x] Verify Firefox addons still build correctly
- [x] Check that all existing addons remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)