### PR TITLE
ci: replace macos-13 with macos-15-intel runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-latest # M1
-          - macos-13 # Intel
+          - macos-15-intel # Intel
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository


### PR DESCRIPTION
macos-13 runner used for Intel CPU support has been deprecated, so replacing it with macos-15-intel to maintain Intel architecture coverage in CI workflow.