### PR TITLE
fix(copyq-darwin): adapt to upstream asset rename

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -29,11 +29,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-LrdDzFepf95scdbsBYdAiuK+tBk5aZEX0yt05oiC534=",
+            "sha256": "sha256-Es4AeDdpFeSVD/y7cgcPv2ugp5xdlsGTA5+9vXQl81M=",
             "type": "url",
-            "url": "https://github.com/hluk/CopyQ/releases/download/v13.0.0/CopyQ-macos-12-m1.dmg.zip"
+            "url": "https://github.com/hluk/CopyQ/releases/download/v15.0.0/CopyQ-15.0.0-macos-12-m1.dmg"
         },
-        "version": "13.0.0"
+        "version": "15.0.0"
     },
     "emacs-plus": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -20,10 +20,10 @@
   };
   copyq-darwin = {
     pname = "copyq-darwin";
-    version = "13.0.0";
+    version = "15.0.0";
     src = fetchurl {
-      url = "https://github.com/hluk/CopyQ/releases/download/v13.0.0/CopyQ-macos-12-m1.dmg.zip";
-      sha256 = "sha256-LrdDzFepf95scdbsBYdAiuK+tBk5aZEX0yt05oiC534=";
+      url = "https://github.com/hluk/CopyQ/releases/download/v15.0.0/CopyQ-15.0.0-macos-12-m1.dmg";
+      sha256 = "sha256-Es4AeDdpFeSVD/y7cgcPv2ugp5xdlsGTA5+9vXQl81M=";
     };
   };
   emacs-plus = {

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -6,7 +6,7 @@ fetch.github = "coder/claudecode.nvim"
 [copyq-darwin]
 src.github = "hluk/CopyQ"
 src.prefix = "v"
-fetch.url = "https://github.com/hluk/CopyQ/releases/download/v$ver/CopyQ-macos-12-m1.dmg.zip"
+fetch.url = "https://github.com/hluk/CopyQ/releases/download/v$ver/CopyQ-$ver-macos-12-m1.dmg"
 
 [emacs-plus]
 src.git = "https://github.com/d12frosted/homebrew-emacs-plus"

--- a/overlays/copyq/default.nix
+++ b/overlays/copyq/default.nix
@@ -30,12 +30,10 @@ in
 
         nativeBuildInputs = [
           prev.undmg
-          prev.unzip
         ];
 
         unpackCmd = ''
-          unzip $curSrc
-          undmg CopyQ.dmg
+          undmg $curSrc
         '';
 
         sourceRoot = "CopyQ.app";


### PR DESCRIPTION
## Summary
- The update workflow failed on v15.0.0 because CopyQ renamed its macOS release asset starting at v14.0.0 (`CopyQ-macos-12-m1.dmg.zip` → `CopyQ-<ver>-macos-12-m1.dmg`), producing a 404 in nvfetcher.
- Update the nvfetcher URL template to the new versioned `.dmg` name.
- Drop the unzip step from the darwin overlay since the dmg is no longer wrapped in a zip.
- Regenerate `_sources/` (bumps copyq-darwin 13.0.0 → 15.0.0).

Failed run: https://github.com/natsukium/nur-packages/actions/runs/24799804061

## Test plan
- [x] `nvfetcher -f copyq-darwin` succeeds
- [x] `nix-build` of the overridden `copyq` package succeeds locally on aarch64-darwin
- [ ] CI update workflow passes on the next scheduled run