### PR TITLE
chore: drop x86_64-darwin support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-latest # M1
-          - macos-15-intel # Intel
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
       systems = [
         "x86_64-linux"
         "i686-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
         "aarch64-linux"
         "armv6l-linux"


### PR DESCRIPTION
Intel macOS (x86_64-darwin) has reached end of support, so remove it from the supported systems and the CI build matrix.