### PR TITLE
ci: use nix-quick-install-action to speed up Nix setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Install nix
-      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+      uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
       with:
-        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        nix_conf: |
+          experimental-features = nix-command flakes
     - name: Setup cachix
       uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
       with:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,9 +19,9 @@ jobs:
         token: ${{ steps.app-token.outputs.token }}
         persist-credentials: false
     - name: Install nix
-      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+      uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
       with:
-        extra_nix_config: |
+        nix_conf: |
           experimental-features = nix-command flakes
     - name: Update flake inputs
       run: nix flake update

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,9 +19,9 @@ jobs:
         token: ${{ steps.app-token.outputs.token }}
         persist-credentials: false
     - name: Install nix
-      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+      uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
       with:
-        extra_nix_config: |
+        nix_conf: |
           experimental-features = nix-command flakes
     - name: Update sources
       run: nix run nixpkgs#nvfetcher


### PR DESCRIPTION
cachix/install-nix-action performs a full multi-user daemon install, which is slow to set up on macOS runners. nix-quick-install-action installs Nix in single-user mode from a prebuilt archive, cutting install time significantly.

Since this action — unlike install-nix-action — does not enable `nix-command` and `flakes` by default, they are enabled explicitly via `nix_conf`.

Opening this to verify CI (especially the macOS runner) passes with the new installer.