### PR TITLE
emacs-plus: apply the patches upstream ships for each Emacs version

### DIFF
--- a/pkgs/emacs-plus/default.nix
+++ b/pkgs/emacs-plus/default.nix
@@ -9,6 +9,7 @@ emacs.overrideAttrs (
   let
     emacsMajorVersion = lib.versions.major prevAttrs.version;
     emacsOlder = lib.versionOlder prevAttrs.version;
+    emacsAtLeast = lib.versionAtLeast prevAttrs.version;
   in
   {
     pname = "emacs-plus";
@@ -18,11 +19,17 @@ emacs.overrideAttrs (
       (prevAttrs.patches or [ ])
       ++ map (p: "${source.src}/patches/emacs-${emacsMajorVersion}/${p}") (
         [
-          "fix-window-role.patch"
           "round-undecorated-frame.patch"
           "system-appearance.patch"
         ]
         ++ lib.optional (emacsOlder "30") "no-frame-refocus-cocoa.patch"
+        # upstream emacs 31 no longer needs the window role workaround
+        ++ lib.optional (emacsOlder "31") "fix-window-role.patch"
+        # x-colors is dumped in a headless builder and ends up with a truncated
+        # color list, so refresh it when the display becomes available
+        ++ lib.optional (emacsAtLeast "30") "fix-ns-x-colors.patch"
+        # macOS 26 (Tahoe) scrolling lag; merged upstream into emacs 31
+        ++ lib.optional (emacsAtLeast "30" && emacsOlder "31") "fix-macos-tahoe-scrolling.patch"
       );
 
     configureFlags = (prevAttrs.configureFlags or [ ]) ++ [


### PR DESCRIPTION
`homebrew-emacs-plus` lists five patches in the `emacs-plus@30` Formula, but only three were applied here.

## Added

| patch | 29 | 30 | 31 / 32 |
|---|---|---|---|
| round-undecorated-frame / system-appearance | ✓ | ✓ | ✓ |
| no-frame-refocus-cocoa | ✓ | – | – |
| fix-window-role | ✓ | ✓ | – |
| **fix-ns-x-colors** | – | ✓ | ✓ |
| **fix-macos-tahoe-scrolling** | – | ✓ | – |

- **fix-ns-x-colors** — `x-colors` is populated by `ns-list-colors` at dump time. Dumped in a headless builder it only gets ~62 colors instead of the full ~800, so it is refreshed during `window-system-initialization`. Only shipped for Emacs 30 and newer.
- **fix-macos-tahoe-scrolling** — disables `NSEventConcurrentProcessingEnabled` / `NSApplicationUpdateCycleEnabled` on macOS 26, which otherwise cause scrolling lag. Gated to Emacs 30 only: it was [merged into Emacs master](https://github.com/emacs-mirror/emacs/commit/046f5ef018997e8ef60d2157864ed7d02934d81f) and upstream removed it from `patches/emacs-31` (d12frosted/homebrew-emacs-plus@19b50cd).

`fix-window-role` is now gated below 31 for the same reason — upstream deleted `patches/emacs-31/fix-window-role.patch`, so leaving it unconditional would break the build once Emacs 31 lands.

`patches/emacs-{29,30}/treesit-compatibility.patch` is deliberately left out: no Formula references it, and nixpkgs already applies its own `01_all_treesit-0.26.patch`.

## Testing

Applied the nixpkgs patch set followed by all five emacs-plus patches to the Emacs 30.2 source in order — every hunk applies with no conflicts.